### PR TITLE
Replace LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4060,6 +4060,7 @@ dependencies = [
  "itertools 0.13.0",
  "num-bigint",
  "num-traits",
+ "once_cell",
  "predicates",
  "reqwest 0.12.7",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ uuid = "1.9.1"
 
 [build-dependencies]
 flate2 = "1.0.30"
+once_cell = "1.18"
 reqwest = { version = "0.12.5", features = ["blocking"] }
 serde = { version = "1.0", features = ["derive"], default-features = false }
 serde_json = "1"

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::env::consts::{ARCH, OS};
@@ -5,12 +6,11 @@ use std::ffi::OsStr;
 use std::fs::{metadata, remove_file, set_permissions};
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
-use std::sync::LazyLock;
 use thiserror::Error;
 
 const CONFIG: &str = include_str!("configs/env.json");
 
-static DISTS: LazyLock<HashMap<(Os, Arch), Artifacts>> = LazyLock::new(|| {
+static DISTS: Lazy<HashMap<(Os, Arch), Artifacts>> = Lazy::new(|| {
     let mut m = HashMap::new();
     m.insert((Os::Linux, Arch::Amd64), Artifacts {
         url: "https://github.com/zksecurity/stone-cli/releases/download/v0.1.0-alpha/stone-cli-linux-x86_64.tar.gz".to_string(),


### PR DESCRIPTION
LazyLock requires rust v1.80.0 since it was added to std lib in that version. Replacing it with once_cell::sync::Lazy to support lower versions of Rust.