### PR TITLE
config rustc compiler RUST_MIN_STACK

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+RUST_MIN_STACK = "16777216"


### PR DESCRIPTION
**Summary**  
This PR increases the Rust compiler stack size in `.cargo/config.toml` to successfully compile the `swiftness` AIR for [starknet_with_keccak](https://github.com/iosis-tech/swiftness/blob/main/crates/air/src/layout/starknet_with_keccak/autogenerated/autogenerated_composition.rs#L9981) and [dynamic](https://github.com/iosis-tech/swiftness/blob/main/crates/air/src/layout/dynamic/autogenerated/autogenerated_composition.rs#L15472) layouts. 

**Details**  
The change is required because the `swiftness` package, which this project depends on for integrity proof serialization, cannot compile with the default stack size. This was the only issue encountered when running the project without prior setup or preparation.  

**References**  
- Link to `swiftness` config: https://github.com/iosis-tech/swiftness/blob/main/.cargo/config.toml  