### PR TITLE
Add new prove command

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 pub enum Cli {
     Prove(ProveArgs),
     ProveBootloader(ProveBootloaderArgs),
+    ProveWithCairoRunArtifacts(ProveWithCairoRunArtifactsArgs),
     Verify(VerifyArgs),
     SerializeProof(SerializeArgs),
 }
@@ -96,6 +97,39 @@ pub struct ProveBootloaderArgs {
         help = "Option to ignore fact topologies, which will result in task outputs being written only to public memory page 0"
     )]
     pub ignore_fact_topologies: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct ProveWithCairoRunArtifactsArgs {
+    #[clap(long = "air_public_input", value_hint=ValueHint::FilePath)]
+    pub air_public_input: PathBuf,
+
+    #[clap(long = "air_private_input", value_hint=ValueHint::FilePath)]
+    pub air_private_input: PathBuf,
+
+    #[clap(long = "memory_file", value_hint=ValueHint::FilePath)]
+    pub memory_file: PathBuf,
+
+    #[clap(long = "trace_file", value_hint=ValueHint::FilePath)]
+    pub trace_file: PathBuf,
+
+    #[clap(long = "prover_config_file", conflicts_with_all = ["store_full_lde", "use_fft_for_eval", "constraint_polynomial_task_size", "n_out_of_memory_merkle_layers", "table_prover_n_tasks_per_segment"])]
+    pub prover_config_file: Option<PathBuf>,
+
+    #[clap(long = "parameter_file", conflicts_with_all = ["field", "channel_hash", "commitment_hash", "n_verifier_friendly_commitment_layers", "pow_hash", "page_hash", "fri_step_list", "last_layer_degree_bound", "n_queries", "proof_of_work_bits", "log_n_cosets", "use_extension_field", "verifier_friendly_channel_updates", "verifier_friendly_commitment_hash"])]
+    pub parameter_file: Option<PathBuf>,
+
+    #[clap(long = "output", default_value = "./bootloader_proof.json")]
+    pub output: PathBuf,
+
+    #[clap(long = "stone_version", default_value = "v6", value_enum)]
+    pub stone_version: StoneVersion,
+
+    #[clap(flatten)]
+    pub parameter_config: ProverParametersConfig,
+
+    #[clap(flatten)]
+    pub prover_config: ProverConfig,
 }
 
 #[derive(Args, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,9 @@ use clap::Parser;
 use stone_cli::args::Cli;
 use stone_cli::bootloader::run_bootloader;
 use stone_cli::cairo::run_cairo;
-use stone_cli::prover::{run_stone_prover, run_stone_prover_bootloader};
+use stone_cli::prover::{
+    run_stone_prover, run_stone_prover_bootloader, run_stone_prover_with_cairo_run_artifacts,
+};
 use stone_cli::serialize::serialize_proof;
 use stone_cli::utils::{cleanup_tmp_files, parse, set_env_vars};
 use stone_cli::verifier::run_stone_verifier;
@@ -59,6 +61,21 @@ fn main() -> anyhow::Result<()> {
                     )
                     .map_err(|e| anyhow::anyhow!("Failed to run stone prover: {}", e))
                 });
+            match result {
+                Ok(_) => {
+                    cleanup_tmp_files(&tmp_dir);
+                    Ok(())
+                }
+                Err(err) => {
+                    cleanup_tmp_files(&tmp_dir);
+                    Err(err)
+                }
+            }
+        }
+        Cli::ProveWithCairoRunArtifacts(args) => {
+            let result = run_stone_prover_with_cairo_run_artifacts(&args, &tmp_dir).map_err(|e| {
+                anyhow::anyhow!("Failed to run stone prover with cairo run artifacts: {}", e)
+            });
             match result {
                 Ok(_) => {
                     cleanup_tmp_files(&tmp_dir);


### PR DESCRIPTION
`prove-with-cairo-run-artifacts` allows running the stone prover with the artifacts from cairo-run (public input, private input, memory, trace files)