### PR TITLE
Minor Fixes: Typo Correction and Comment Update

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -27,7 +27,7 @@ const BIN_STONE_V6_PROVER: &str = "cpu_air_prover_v6";
 const BIN_STONE_V5_VERIFIER: &str = "cpu_air_verifier_v5";
 const BIN_STONE_V6_VERIFIER: &str = "cpu_air_verifier_v6";
 
-// excutables to add to the resources
+// executables to add to the resources
 const EXECUTABLES: [(&str, &str); 4] = [
     (RES_STONE_V5_PROVER, BIN_STONE_V5_PROVER),
     (RES_STONE_V5_VERIFIER, BIN_STONE_V5_VERIFIER),

--- a/examples/dict_with_struct.cairo
+++ b/examples/dict_with_struct.cairo
@@ -21,7 +21,7 @@ fn main() -> Array<felt252> {
     d.insert(2, nullable_from_box(box_b));
 
     // We can't implement Serde for a Felt252Dict due to mutability requirements
-    // So we will serialize the dict explicitely
+    // So we will serialize the dict explicitly
     let mut output: Array<felt252> = ArrayTrait::new();
     // Serialize entry 0
     0.serialize(ref output);


### PR DESCRIPTION


Description:  
This pull request includes minor improvements in two files:
- In build.rs, the comment for executables was updated for clarity.
- In examples/dict_with_struct.cairo, a typo in the comment ("explicitely" → "explicitly") was corrected.

No functional code changes were made; only comments were updated for better readability and accuracy.